### PR TITLE
Fix: Resolved Sidebar Home button and Header Overlap Issue

### DIFF
--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -272,7 +272,7 @@ const Sidebar: React.FC<SidebarProps> = ({
         ref={sidebarRef}
         onMouseEnter={handleMouseEnterSidebar}
         onMouseLeave={handleMouseLeaveSidebar}
-        className={`fixed top-0 left-0 h-full bg-white dark:bg-gray-800 shadow-lg transition-all duration-300 ease-in-out flex flex-col ${currentWidthClass} py-4`}
+        className={`fixed top-[64px] left-0 h-[calc(100vh-64px)] bg-white dark:bg-gray-800 shadow-lg transition-all duration-300 ease-in-out flex flex-col ${currentWidthClass} py-4`}
         style={{ 
           zIndex: 40,
           position: 'fixed'


### PR DESCRIPTION
DESCRIPTION:
Fixed the issue where the Home button in the sidebar was getting hidden behind the header due to overlapping positioning. This was affecting user navigation and layout consistency.

FIX:
Applied top margin (mt-16) to the Sidebar component to push it below the fixed Header
Ensures clear separation between the header and sidebar

SCREENSHOT: 
<img width="1907" height="856" alt="Screenshot 2025-07-23 171321" src="https://github.com/user-attachments/assets/b6c8770d-d4b1-47ef-bd76-7b07a61eae48" />




