### PR TITLE
Fix: Make testimonial cards uniform height and visually aligned (GSSoC 25)

### DIFF
--- a/components/TestimonialsSlider.tsx
+++ b/components/TestimonialsSlider.tsx
@@ -62,11 +62,11 @@ const TestimonialsSlider: React.FC<TestimonialsSliderProps> = ({
           pauseOnMouseEnter: true
         } : false}
         loop={true}
-        className="py-8"
+        className="py-8 h-[320px] md:h-[320px]"
       >
         {testimonials.map((testimonial) => (
-          <SwiperSlide key={testimonial.id}>
-            <div className="bg-brand-off-white dark:bg-brand-dark-gray p-6 rounded-xl shadow-lg flex flex-col items-center text-center transform hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 backdrop-blur-sm bg-opacity-90 dark:bg-opacity-90 h-full">
+          <SwiperSlide key={testimonial.id} className="h-full flex">
+            <div className="bg-brand-off-white dark:bg-brand-dark-gray p-6 rounded-xl shadow-lg flex flex-col justify-between items-center text-center min-h-[260px] h-full w-full transform hover:shadow-2xl hover:-translate-y-1 transition-all duration-300 backdrop-blur-sm bg-opacity-90 dark:bg-opacity-90">
               <img 
                 src={testimonial.avatarUrl || `https://ui-avatars.com/api/?name=${encodeURIComponent(testimonial.name)}&background=random&color=fff&size=96`} 
                 alt={testimonial.name} 


### PR DESCRIPTION
## Related Issue
Closes #17

## What does this PR do?
This PR ensures that all testimonial cards in the "Here's what our learners have to say..." section have a uniform height and are visually aligned, regardless of the testimonial text length. This addresses the jagged, unbalanced look on medium screen sizes.

## Changes made
- Set a consistent minimum height for testimonial cards using Tailwind's `min-h-[260px]`.
- Applied `flex flex-col justify-between` for vertical alignment and even spacing.
- Updated Swiper and SwiperSlide containers to enforce equal height for all cards.

## Motivation
Improves the visual consistency and user experience of the testimonials section, especially on medium screens, as required by GSSoC 25.

## Checklist
- > All testimonial cards have a uniform height
- >Cards are visually aligned on all screen sizes
- > No breaking changes introduced
