### PR TITLE
Fix: Add hover effect to footer social icons and text

### DIFF
--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -100,10 +100,12 @@ const Footer: React.FC<FooterProps> = ({ layoutStyle }) => {
           href={social.href}
           target="_blank"
           rel="noopener noreferrer"
-          className={`flex items-center text-gray-600 dark:text-brand-medium-gray ${social.color} hover:underline transition-colors duration-200`}
-        >
-          <social.icon className="w-5 h-5 mr-2" />
-          {social.label}
+          className="group flex items-center transition-colors duration-200">
+          <social.icon className="w-5 h-5 mr-2 text-white group-hover:text-brand-ninja-gold transition-colors duration-200" />
+          <span className="text-white group-hover:text-brand-ninja-gold transition-colors duration-200">
+  {social.label}
+</span>
+
         </a>
       </li>
     ))}

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -101,8 +101,9 @@ const Footer: React.FC<FooterProps> = ({ layoutStyle }) => {
           target="_blank"
           rel="noopener noreferrer"
           className="group flex items-center transition-colors duration-200">
-          <social.icon className="w-5 h-5 mr-2 text-white group-hover:text-brand-ninja-gold transition-colors duration-200" />
-          <span className="text-white group-hover:text-brand-ninja-gold transition-colors duration-200">
+          <social.icon className="w-5 h-5 mr-2 text-gray-600 dark:text-gray-300 group-hover:text-brand-primary dark:group-hover:text-brand-ninja-gold transition-colors duration-200" />
+<span className="text-gray-600 dark:text-gray-300 group-hover:text-brand-primary dark:group-hover:text-brand-ninja-gold transition-colors duration-200">
+
   {social.label}
 </span>
 


### PR DESCRIPTION
Closes #79 

**DESCRIPTION**

1) Improved the hover behavior in the "Connect With Us" section of the footer.
2) Both the icon and its label text now smoothly turn to our brand-primary orange on hover.
3) Initially, everything stays clean and white — no underline, no clutter.

**SCREENSHOT**

<img width="355" height="419" alt="Screenshot 2025-07-25 125259" src="https://github.com/user-attachments/assets/98ad9508-d149-421d-ab29-071e01b7ceab" />

<img width="709" height="429" alt="image" src="https://github.com/user-attachments/assets/f7f3fc17-3a18-4b84-8c7a-6dd1bbe4c7d7" />


