### PR TITLE
🎨 Fix: Smooth transition between hero section and community stats

### DIFF
--- a/components/SectionDivider.tsx
+++ b/components/SectionDivider.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface SectionDividerProps {
+  className?: string;
+  fillColor?: string;
+  style?: 'wave' | 'curve' | 'angle';
+  flip?: boolean;
+}
+
+const SectionDivider: React.FC<SectionDividerProps> = ({ 
+  className = '', 
+  fillColor = 'currentColor',
+  style = 'wave',
+  flip = false
+}) => {
+  const getPath = () => {
+    switch (style) {
+      case 'curve':
+        return "M0,32L48,37.3C96,43,192,53,288,48C384,43,480,21,576,16C672,11,768,21,864,26.7C960,32,1056,32,1152,32C1248,32,1344,32,1392,32L1440,32L1440,0L1392,0C1344,0,1248,0,1152,0C1056,0,960,0,864,0C768,0,672,0,576,0C480,0,384,0,288,0C192,0,96,0,48,0L0,0Z";
+      case 'angle':
+        return "M0,0L1440,32L1440,0Z";
+      default: // wave
+        return "M0,32L60,42.7C120,53,240,75,360,85.3C480,96,600,96,720,80C840,64,960,32,1080,26.7C1200,21,1320,43,1380,53.3L1440,64L1440,0L1380,0C1320,0,1200,0,1080,0C960,0,840,0,720,0C600,0,480,0,360,0C240,0,120,0,60,0L0,0Z";
+    }
+  };
+
+  return (
+    <div className={`absolute bottom-0 left-0 right-0 ${flip ? 'transform rotate-180' : ''} ${className}`}>
+      <svg 
+        viewBox="0 0 1440 64" 
+        className="w-full h-8 md:h-12 lg:h-16"
+        preserveAspectRatio="none"
+      >
+        <path 
+          d={getPath()}
+          fill={fillColor}
+          className="drop-shadow-sm"
+        />
+      </svg>
+    </div>
+  );
+};
+
+export default SectionDivider;

--- a/components/pages/HomePage.tsx
+++ b/components/pages/HomePage.tsx
@@ -45,6 +45,8 @@ const HeroSection: React.FC = () => {
         style="matrix"
         className="absolute inset-0 z-0"
       />
+      {/* Smooth transition gradient overlay */}
+      <div className="absolute bottom-0 left-0 right-0 h-20 bg-gradient-to-b from-transparent to-brand-off-white dark:to-brand-dark-gray z-5"></div>
       <div className="container mx-auto px-4 text-center relative z-10">
         <RevealOnScroll direction="down" duration={1000}>
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold mb-6 text-orange-500 dark:text-white">
@@ -379,7 +381,7 @@ const ExploreFeaturesSection: React.FC = () => {
         style="terminal"
         className="absolute inset-0 z-0"
       />
-      <div className="relative flex flex-col justify-between container mx-auto px-4 md:px-8 max-w-screen-xl text-center relative z-10">
+      <div className="relative flex flex-col justify-between container mx-auto px-4 md:px-8 max-w-screen-xl text-center z-10">
 
         <RevealOnScroll direction="up" duration={800}>
           <h2 className="text-3xl font-bold mb-12 text-brand-dark-gray dark:text-white">


### PR DESCRIPTION
## 🎯 Problem
The transition between the hero section (with matrix-style animated background) and the section below ("The TechXNinjas tribe is growing...") was visually abrupt, causing a jarring user experience and breaking the visual flow of the page.

## ✅ Solution
- **Added gradient overlay** at the bottom of hero section for seamless visual transition
- **Theme-aware implementation** - works perfectly in both light and dark modes
- **Fixed CSS lint warning** for duplicate classes
- **Added bonus component** - `SectionDivider` for future use with wave/curve transitions

## 🧪 Testing Done
- [x] ✅ Tested in light mode - smooth transition ✨
- [x] ✅ Tested in dark mode - consistent theming 🌙
- [x] ✅ Responsive on mobile/tablet/desktop 📱💻
- [x] ✅ No lint errors or warnings 🔧
- [x] ✅ Dev server runs without issues 🚀

## 📱 Screenshots
**Before**: Abrupt transition with visual cutoff
**After**: Smooth gradient blend between sections

## 🏷️ Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement
- [x] ✨ Enhancement (improves user experience)

## 📋 Related Issues
Fixes the visual transition issue described in the homepage user experience