### PR TITLE
Add eye button to toggle password visibility in login and registratio…

### DIFF
--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -4,6 +4,7 @@ import { AuthContext } from '../../contexts/AuthContext';
 import { AuthContextType } from '../../types';
 import { GoogleIcon } from '../icons';
 import { Turnstile } from '@marsidev/react-turnstile';
+import { Eye, EyeOff } from 'lucide-react';
 
 interface LoginFormProps {
   onSwitchToRegister: () => void;
@@ -24,6 +25,8 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
   
   const [captchaToken, setCaptchaToken] = useState<string | undefined>();
   const [captchaError, setCaptchaError] = useState<string | null>(null);
+  const [showPassword, setShowPassword] = useState<Boolean>(false);
+
   const turnstileSiteKey = '0x4AAAAAABhuYfA0fxpwvokl';
 
   const auth = useContext(AuthContext) as AuthContextType;
@@ -127,24 +130,38 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
 
   return (
     <>
-      <div className="mb-6 flex border-b border-gray-200 dark:border-gray-700" role="tablist" aria-label="Login methods">
-        <TabButton tabId="emailPassword" currentTab={activeTab} onClick={() => setActiveTab('emailPassword')}>
+      <div
+        className="mb-6 flex border-b border-gray-200 dark:border-gray-700"
+        role="tablist"
+        aria-label="Login methods"
+      >
+        <TabButton
+          tabId="emailPassword"
+          currentTab={activeTab}
+          onClick={() => setActiveTab("emailPassword")}
+        >
           Email & Password
         </TabButton>
-        <TabButton tabId="magicLink" currentTab={activeTab} onClick={() => setActiveTab('magicLink')}>
+        <TabButton
+          tabId="magicLink"
+          currentTab={activeTab}
+          onClick={() => setActiveTab("magicLink")}
+        >
           Magic Link
         </TabButton>
       </div>
 
       {/* Turnstile is now rendered inside each tab's form */}
 
-      {activeTab === 'emailPassword' && (
+      {activeTab === "emailPassword" && (
         <form onSubmit={handleEmailPasswordSubmit} className="space-y-4">
           <div>
             <button
               type="button"
               onClick={handleGoogleSignIn}
-              disabled={auth.loading /* Potentially add || !captchaToken if gating Google button */}
+              disabled={
+                auth.loading /* Potentially add || !captchaToken if gating Google button */
+              }
               className="w-full flex items-center justify-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-primary disabled:opacity-50 dark:focus:ring-offset-gray-800"
             >
               <GoogleIcon className="w-5 h-5 mr-2" />
@@ -153,7 +170,10 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
           </div>
 
           <div className="relative">
-            <div className="absolute inset-0 flex items-center" aria-hidden="true">
+            <div
+              className="absolute inset-0 flex items-center"
+              aria-hidden="true"
+            >
               <div className="w-full border-t border-gray-300 dark:border-gray-600" />
             </div>
             <div className="relative flex justify-center text-sm">
@@ -162,9 +182,12 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
               </span>
             </div>
           </div>
-          
+
           <div>
-            <label htmlFor="email-login" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label
+              htmlFor="email-login"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
               Email address
             </label>
             <input
@@ -179,22 +202,32 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
             />
           </div>
 
-          <div>
-            <label htmlFor="password-login" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          <div className="relative">
+            <label
+              htmlFor="password-login"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
               Password
             </label>
             <input
               id="password-login"
               name="password"
-              type="password"
+              type={showPassword ? "text" : "password"}
               autoComplete="current-password"
               required
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-brand-primary focus:border-brand-primary sm:text-sm dark:bg-gray-700 dark:text-white"
             />
+
+            <button
+              onClick={() => setShowPassword(!showPassword)}
+              className="cursor-pointer absolute top-6 right-0 pr-3 flex items-center h-10"
+            >
+              {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+            </button>
           </div>
-          
+
           <div className="flex items-center justify-end text-sm">
             <button
               type="button"
@@ -204,7 +237,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
               Forgot your password?
             </button>
           </div>
-          
+
           {renderTurnstile()}
 
           <div>
@@ -213,16 +246,19 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
               disabled={auth.loading || !captchaToken || !turnstileSiteKey}
               className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-primary hover:bg-ninja-gold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-primary disabled:opacity-50 dark:focus:ring-offset-gray-800"
             >
-              {auth.loading ? 'Logging in...' : 'Login'}
+              {auth.loading ? "Logging in..." : "Login"}
             </button>
           </div>
         </form>
       )}
 
-      {activeTab === 'magicLink' && (
+      {activeTab === "magicLink" && (
         <form onSubmit={handleSendMagicLink} className="space-y-4">
           <div>
-            <label htmlFor="magic-link-email" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label
+              htmlFor="magic-link-email"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
               Email address
             </label>
             <input
@@ -243,7 +279,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
             </div>
           )}
           {magicLinkError && (
-             <div className="p-3 bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-200 rounded-md text-sm">
+            <div className="p-3 bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-200 rounded-md text-sm">
               <p>{magicLinkError}</p>
             </div>
           )}
@@ -256,7 +292,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
               disabled={auth.loading || !captchaToken || !turnstileSiteKey}
               className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-primary hover:bg-ninja-gold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-primary disabled:opacity-50 dark:focus:ring-offset-gray-800"
             >
-              {auth.loading ? 'Sending...' : 'Send Magic Link'}
+              {auth.loading ? "Sending..." : "Send Magic Link"}
             </button>
           </div>
         </form>
@@ -265,16 +301,16 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
       {/* Privacy and Terms Disclaimer */}
       <div className="mt-4 text-center">
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          By logging in, you agree to our{' '}
-          <Link 
-            to="/privacy" 
+          By logging in, you agree to our{" "}
+          <Link
+            to="/privacy"
             className="text-brand-primary hover:text-ninja-gold dark:text-ninja-gold dark:hover:text-brand-primary underline"
           >
             Privacy Policy
-          </Link>
-          {' '}and{' '}
-          <Link 
-            to="/terms" 
+          </Link>{" "}
+          and{" "}
+          <Link
+            to="/terms"
             className="text-brand-primary hover:text-ninja-gold dark:text-ninja-gold dark:hover:text-brand-primary underline"
           >
             Terms of Service
@@ -285,7 +321,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onSwitchToFor
 
       <div className="mt-6 text-sm text-center">
         <p className="text-gray-600 dark:text-gray-400">
-          Don't have an account?{' '}
+          Don't have an account?{" "}
           <button
             type="button"
             onClick={onSwitchToRegister}

--- a/components/auth/RegisterForm.tsx
+++ b/components/auth/RegisterForm.tsx
@@ -4,6 +4,7 @@ import { AuthContext } from '../../contexts/AuthContext';
 import { AuthContextType } from '../../types';
 import { GoogleIcon } from '../icons';
 import { Turnstile } from '@marsidev/react-turnstile';
+import { Eye, EyeOff } from "lucide-react";
 
 interface RegisterFormProps {
   onSwitchToLogin: () => void;
@@ -17,7 +18,9 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin, onSuccess 
   const [confirmPassword, setConfirmPassword] = useState('');
   const [captchaToken, setCaptchaToken] = useState<string | undefined>();
   const [captchaError, setCaptchaError] = useState<string | null>(null);
-  const turnstileSiteKey = '0x4AAAAAABhuYfA0fxpwvokl';
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+    const turnstileSiteKey = '0x4AAAAAABhuYfA0fxpwvokl';
   
   const auth = useContext(AuthContext) as AuthContextType;
   const [formError, setFormError] = useState<string | null>(null);
@@ -70,11 +73,13 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin, onSuccess 
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-       <div>
+      <div>
         <button
           type="button"
           onClick={handleGoogleSignIn}
-          disabled={auth.loading /* Potentially add || !captchaToken if gating Google button */}
+          disabled={
+            auth.loading /* Potentially add || !captchaToken if gating Google button */
+          }
           className="w-full flex items-center justify-center py-2.5 px-4 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-primary disabled:opacity-50 dark:focus:ring-offset-gray-800"
         >
           <GoogleIcon className="w-5 h-5 mr-2" />
@@ -99,7 +104,10 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin, onSuccess 
         </div>
       )}
       <div>
-        <label htmlFor="name-register" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+        <label
+          htmlFor="name-register"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
           Full Name
         </label>
         <input
@@ -114,7 +122,10 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin, onSuccess 
         />
       </div>
       <div>
-        <label htmlFor="email-register" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+        <label
+          htmlFor="email-register"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
           Email address
         </label>
         <input
@@ -129,55 +140,95 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin, onSuccess 
         />
       </div>
 
-      <div>
-        <label htmlFor="password-register" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+      <div className="relative">
+        <label
+          htmlFor="password-register"
+          className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
           Password
         </label>
         <input
           id="password-register"
           name="password"
-          type="password"
+          type={showPassword ? "text" : "password"}
           autoComplete="new-password"
           required
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-brand-primary focus:border-brand-primary sm:text-sm dark:bg-gray-700 dark:text-white"
         />
-      </div>
-      
-      <div>
-        <label htmlFor="confirm-password-register" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-          Confirm Password
-        </label>
-        <input
-          id="confirm-password-register"
-          name="confirmPassword"
-          type="password"
-          autoComplete="new-password"
-          required
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-brand-primary focus:border-brand-primary sm:text-sm dark:bg-gray-700 dark:text-white"
-        />
+        <button
+          type="button"
+          onClick={() => setShowPassword(!showPassword)}
+          className="absolute top-6 right-0 pr-3 flex items-center text-gray-500 dark:text-gray-300 h-10"
+        >
+          {showPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+        </button>
       </div>
 
-      <div className="my-4 flex justify-center"> {/* Centering classes moved here */}
+      <div>
+        <div className="relative">
+          <label
+            htmlFor="confirm-password-register"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Confirm Password
+          </label>
+          <input
+            id="confirm-password-register"
+            name="confirmPassword"
+            type={showConfirmPassword ? "text" : "password"}
+            autoComplete="new-password"
+            required
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-brand-primary focus:border-brand-primary sm:text-sm dark:bg-gray-700 dark:text-white"
+          />
+          <button
+            type="button"
+            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+            className="absolute top-6 right-0 pr-3 flex items-center text-gray-500 dark:text-gray-300 h-10"
+          >
+            {showConfirmPassword ? <EyeOff size={18} /> : <Eye size={18} />}
+          </button>
+        </div>
+      </div>
+
+      <div className="my-4 flex justify-center">
+        {" "}
+        {/* Centering classes moved here */}
         {!turnstileSiteKey ? (
-            <div className="p-3 bg-yellow-50 dark:bg-yellow-900 border border-yellow-300 dark:border-yellow-700 text-yellow-700 dark:text-yellow-200 rounded-md text-sm text-center">
-                CAPTCHA is not configured. Please contact support.
-            </div>
+          <div className="p-3 bg-yellow-50 dark:bg-yellow-900 border border-yellow-300 dark:border-yellow-700 text-yellow-700 dark:text-yellow-200 rounded-md text-sm text-center">
+            CAPTCHA is not configured. Please contact support.
+          </div>
         ) : (
-            <Turnstile
-                siteKey={turnstileSiteKey}
-                onSuccess={setCaptchaToken}
-                onError={() => { setCaptchaError("CAPTCHA challenge failed. Please refresh and try again."); setCaptchaToken(undefined); }}
-                onExpire={() => { setCaptchaError("CAPTCHA challenge expired. Please refresh and try again."); setCaptchaToken(undefined); }}
-                options={{ theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light' }}
-                // className="flex justify-center" // Removed from here
-            />
+          <Turnstile
+            siteKey={turnstileSiteKey}
+            onSuccess={setCaptchaToken}
+            onError={() => {
+              setCaptchaError(
+                "CAPTCHA challenge failed. Please refresh and try again."
+              );
+              setCaptchaToken(undefined);
+            }}
+            onExpire={() => {
+              setCaptchaError(
+                "CAPTCHA challenge expired. Please refresh and try again."
+              );
+              setCaptchaToken(undefined);
+            }}
+            options={{
+              theme: document.documentElement.classList.contains("dark")
+                ? "dark"
+                : "light",
+            }}
+            // className="flex justify-center" // Removed from here
+          />
         )}
         {captchaError && (
-            <p className="mt-2 text-xs text-red-600 dark:text-red-400 text-center">{captchaError}</p>
+          <p className="mt-2 text-xs text-red-600 dark:text-red-400 text-center">
+            {captchaError}
+          </p>
         )}
       </div>
 
@@ -187,23 +238,23 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin, onSuccess 
           disabled={auth.loading || !captchaToken || !turnstileSiteKey}
           className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-primary hover:bg-ninja-gold focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-primary disabled:opacity-50 dark:focus:ring-offset-gray-800"
         >
-          {auth.loading ? 'Registering...' : 'Register'}
+          {auth.loading ? "Registering..." : "Register"}
         </button>
       </div>
 
       {/* Privacy and Terms Disclaimer */}
       <div className="mt-4 text-center">
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          By creating an account, you agree to our{' '}
-          <Link 
-            to="/privacy" 
+          By creating an account, you agree to our{" "}
+          <Link
+            to="/privacy"
             className="text-brand-primary hover:text-ninja-gold dark:text-ninja-gold dark:hover:text-brand-primary underline"
           >
             Privacy Policy
-          </Link>
-          {' '}and{' '}
-          <Link 
-            to="/terms" 
+          </Link>{" "}
+          and{" "}
+          <Link
+            to="/terms"
             className="text-brand-primary hover:text-ninja-gold dark:text-ninja-gold dark:hover:text-brand-primary underline"
           >
             Terms of Service
@@ -214,7 +265,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onSwitchToLogin, onSuccess 
 
       <div className="text-sm text-center">
         <p className="text-gray-600 dark:text-gray-400">
-          Already have an account?{' '}
+          Already have an account?{" "}
           <button
             type="button"
             onClick={onSwitchToLogin}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1199,6 +1199,60 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.3",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.11",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.9.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.9.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",


### PR DESCRIPTION
What this PR does:
- Adds an eye button to the password fields in login and registration forms.
- Users can toggle password visibility while typing.
- Improves usability.

Files changed:
- components/auth/LoginForm.tsx
- components/auth/RegisterForm.tsx

How to test:
1. Go to login form, click the eye button to toggle password visibility.
2. Repeat on registration form.

Notes:
- Only a UI change, no backend modifications.
- Closes #211

![ezgif-140298fb2d50f2](https://github.com/user-attachments/assets/ea466e16-2de8-489b-b4bc-7ec4763ca5a5)
![ezgif-4783fde78c6dfd](https://github.com/user-attachments/assets/91d8d657-b05e-4e47-90de-c4e0bb60d4d7)
